### PR TITLE
Multiple logic fixes and edits

### DIFF
--- a/Generator/Logic/LogicFunctions.cs
+++ b/Generator/Logic/LogicFunctions.cs
@@ -225,6 +225,7 @@ namespace TPRandomizer
                 || CanUse(Item.Iron_Boots)
                 || CanUse(Item.Spinner)
                 || CanUse(Item.Shadow_Crystal)
+                || (getItemCount(Item.Progressive_Clawshot) >= 1)
             );
         }
 

--- a/Generator/Logic/LogicFunctions.cs
+++ b/Generator/Logic/LogicFunctions.cs
@@ -1367,7 +1367,7 @@ namespace TPRandomizer
         /// </summary>
         public static bool hasBombs()
         {
-            return (CanUse(Item.Bomb_Bag_And_Bombs) || CanUse(Item.Empty_Bomb_Bag));
+            return ((CanUse(Item.Bomb_Bag_And_Bombs) || CanUse(Item.Empty_Bomb_Bag)) && canLeaveForest());
         }
 
         /// <summary>
@@ -1375,7 +1375,7 @@ namespace TPRandomizer
         /// </summary>
         public static bool CanUseWaterBombs()
         {
-            return (hasBombs() && canLeaveForest());
+            return (hasBombs());
         }
 
         /// <summary>
@@ -1394,14 +1394,11 @@ namespace TPRandomizer
         public static bool canCompleteForestTemple()
         {
             return (
-                ((getItemCount(Item.Forest_Temple_Small_Key) >= 4))
+                (((getItemCount(Item.Forest_Temple_Small_Key) >= 4) && canBurnWebs() && CanDefeatOok()) || (getItemCount(Item.Progressive_Clawshot) >= 1))
                 && CanUse(Item.Boomerang)
                 && (CanUse(Item.North_Faron_Woods_Gate_Key) || Randomizer.RandoSetting.introSkipped)
                 && canBreakMonkeyCage()
                 && CanDefeatWalltula()
-                && CanDefeatBigBaba()
-                && canBurnWebs()
-                && CanDefeatOok()
                 && CanDefeatDiababa()
                 && CanUse(Item.Forest_Temple_Big_Key)
             );

--- a/Generator/World/Checks/Dungeons/Lakebed Temple/Lakebed Temple Before Deku Toad Alcove Chest.json
+++ b/Generator/World/Checks/Dungeons/Lakebed Temple/Lakebed Temple Before Deku Toad Alcove Chest.json
@@ -1,5 +1,5 @@
 {
-    "requirements": "(Lakebed_Temple_Small_Key, 2) and canLaunchBombs",
+    "requirements": "(CanDefeatDekuToad and (Lakebed_Temple_Small_Key, 2) and Zora_Armor and hasBombs and (Progressive_Clawshot, 1)) or ((Lakebed_Temple_Small_Key, 3) and canLaunchBombs)",
     "arcFileValues": [["D_MN01/R09_00.arc", "684C4"]],
     "fileDirectoryType": [0],
     "replacementType": [0],

--- a/Generator/World/Checks/Overworld/Eldin Province/Death Mountain Alcove Chest.json
+++ b/Generator/World/Checks/Overworld/Eldin Province/Death Mountain Alcove Chest.json
@@ -1,5 +1,5 @@
 {
-    "requirements": "canCompleteGoronMines or ((Progressive_Clawshot, 1) and Iron_Boots)",
+    "requirements": "(Room.Goron_Mines_Boss_Room and CanDefeatFyrus) or ((Progressive_Clawshot, 1) and Iron_Boots)",
     "arcFileValues": [["F_SP110/R00_00.arc", "A9C04"]],
     "fileDirectoryType": [0],
     "replacementType": [0],

--- a/Generator/World/Checks/Overworld/Eldin Province/Kakariko Graveyard Golden Wolf.json
+++ b/Generator/World/Checks/Overworld/Eldin Province/Kakariko Graveyard Golden Wolf.json
@@ -1,5 +1,5 @@
 {
-    "requirements": "Shadow_Crystal and Room.Snowpeak_Climb and (Progressive_Fishing_Rod, 2)",
+    "requirements": "Shadow_Crystal and Room.Snowpeak_Climb and (Progressive_Fishing_Rod, 2) and (Progressive_Sword, 1)",
     "arcFileValues": [["bmgres6.arc", "4014"],["bmgres6.arc", "3BDC"],["bmgres6.arc", "4244"],["bmgres6.arc", "46A4"],["bmgres6.arc", "4488"],["bmgres6.arc", "48FC"],["bmgres6.arc", "4B68"]],
     "fileDirectoryType": [1,1,1,1,1,1,1],
     "replacementType": [1,1,1,1,1,1,1],

--- a/Generator/World/Checks/Overworld/Gerudo Desert/Gerudo Desert Golden Wolf.json
+++ b/Generator/World/Checks/Overworld/Gerudo Desert/Gerudo Desert Golden Wolf.json
@@ -1,5 +1,5 @@
 {
-    "requirements": "Shadow_Crystal and Room.Lake_Hylia",
+    "requirements": "Shadow_Crystal and Room.Lake_Hylia and (Progressive_Sword, 1)",
     "arcFileValues": [["bmgres6.arc", "4014"],["bmgres6.arc", "3BDC"],["bmgres6.arc", "4244"],["bmgres6.arc", "46A4"],["bmgres6.arc", "4488"],["bmgres6.arc", "48FC"],["bmgres6.arc", "4B68"]],
     "fileDirectoryType": [1,1,1,1,1,1,1],
     "replacementType": [1,1,1,1,1,1,1],

--- a/Generator/World/Checks/Overworld/Lanayru Province/Fishing Hole Heart Piece.json
+++ b/Generator/World/Checks/Overworld/Lanayru Province/Fishing Hole Heart Piece.json
@@ -1,5 +1,5 @@
 {
-    "requirements": "(Progressive_Clawshot, 1)",
+    "requirements": "(Progressive_Clawshot, 1) or (Progressive_Fishing_Rod, 1)",
     "arcFileValues": [["F_SP127/R00_00.arc", "11F7FF"], ["bmgres7.arc", "381C"], ["bmgres7.arc", "3704"]],
     "fileDirectoryType": [0, 1, 1],
     "replacementType": [0, 2, 2],

--- a/Generator/World/Checks/Overworld/Lanayru Province/Lake Hylia Bridge Cliff Poe.json
+++ b/Generator/World/Checks/Overworld/Lanayru Province/Lake Hylia Bridge Cliff Poe.json
@@ -1,5 +1,5 @@
 {
-    "requirements": "Shadow_Crystal and canLaunchBombs and (Progressive_Clawshot,1)",
+    "requirements": "Shadow_Crystal and canLaunchBombs and (Progressive_Clawshot,1) and ((Setting.mdhSkipped equals True) or (Room.Lakebed_Temple_Boss_Room and CanDefeatMorpheel))",
     "stageIDX": [56],
     "flag": "3B",
     "category": ["Overworld", "Poe", "Lanayru Province"],

--- a/Generator/World/Checks/Overworld/Ordonia Province/Herding Goats Reward.json
+++ b/Generator/World/Checks/Overworld/Ordonia Province/Herding Goats Reward.json
@@ -1,5 +1,5 @@
 {
-    "requirements": "Room.Kakariko_Village",
+    "requirements": "((Progressive_Sword, 1) and (Progressive_Fishing_Rod, 1) and North_Faron_Woods_Gate_Key) or (Setting.introSkipped equals True)",
     "arcFileValues": [["bmgres1.arc", "21ADF"]],
     "fileDirectoryType": [1],
     "replacementType": [0],

--- a/Generator/World/Checks/Overworld/Ordonia Province/Ordon Spring Golden Wolf.json
+++ b/Generator/World/Checks/Overworld/Ordonia Province/Ordon Spring Golden Wolf.json
@@ -1,5 +1,5 @@
 {
-    "requirements": "Shadow_Crystal and Room.Death_Mountain_Trail",
+    "requirements": "Shadow_Crystal and Room.Death_Mountain_Trail and (Progressive_Sword, 1)",
     "arcFileValues": [["bmgres6.arc", "4014"],["bmgres6.arc", "3BDC"],["bmgres6.arc", "4244"],["bmgres6.arc", "46A4"],["bmgres6.arc", "4488"],["bmgres6.arc", "48FC"],["bmgres6.arc", "4B68"]],
     "fileDirectoryType": [1,1,1,1,1,1,1],
     "replacementType": [1,1,1,1,1,1,1],

--- a/Generator/World/Rooms/Dungeons/Forest Temple/Forest Temple Lobby.json
+++ b/Generator/World/Rooms/Dungeons/Forest Temple/Forest Temple Lobby.json
@@ -10,7 +10,7 @@
     [
         "true",
         "true",
-        "canBurnWebs and (((Forest_Temple_Small_Key, 4) and CanDefeatBokoblin) or (Progressive_Clawshot, 1))",
+        "canBurnWebs and (((Forest_Temple_Small_Key, 2) and CanDefeatBokoblin) or (Progressive_Clawshot, 1))",
         "canBurnWebs and CanDefeatBombling and CanDefeatWalltula and CanDefeatBigBaba and CanDefeatBokoblin and canBreakMonkeyCage and (Forest_Temple_Small_Key, 4)"
     ],
     "Checks": 

--- a/Generator/World/Rooms/Overworld/Faron Province/Faron Woods/North Faron Woods.json
+++ b/Generator/World/Rooms/Overworld/Faron Province/Faron Woods/North Faron Woods.json
@@ -8,7 +8,7 @@
     "NeighbourRequirements": 
     [
         "true",
-        "Lantern",
+        "true",
         "Boomerang and Shadow_Crystal"
     ],
     "Checks": 


### PR DESCRIPTION
Made the following logic changes:
• Added missing sword requirement for certain golden wolf checks
• Before Deku Toad Alcove Chest now considers using second key on Deku Toad
• DM Alcove Chest no longer references canCompleteGoronMines
• Fishing Hole HP can be gotten with Fishing Rod
• Hylia Bridge Cliff Poe now requires MDH
• Goat herding requirements match Bo wrestling
• FT West Wing requires 2 keys instead of 4
• Lantern no longer required to enter FT
• hasBombs (and by extension CanUseWaterBombs) now requires canLeaveForest (assuming Barnes sells both bombs and water bombs from the start)
• Modified canCompleteForestTemple since it's still referenced by canLeaveForest
• Bomblings can now be defeated with Clawshot