### PR TITLE
Fix generator.php $seedHash quote issue

### DIFF
--- a/generator.php
+++ b/generator.php
@@ -52,7 +52,7 @@ try
 
     while (@ ob_end_flush()); // end all output buffers if any
 
-    $cmd = "dotnet Generator/bin/Debug/net5.0/TPRandomizer.dll $settingsString '$seedHash'";
+    $cmd = "dotnet Generator/bin/Debug/net5.0/TPRandomizer.dll $settingsString \"$seedHash\"";
     $proc = popen($cmd, 'r'); // for Windows, use popen("start /B ". $cmd, 'r'); 
     echo "<h3>TPR 1.0 Seed generator (pre-alpha)</h3><h4>$seedHash</h4><hr><pre>$cmd\n----\n\n";
     $log = "$cmd\n----\n\n";

--- a/generator.php
+++ b/generator.php
@@ -52,7 +52,7 @@ try
 
     while (@ ob_end_flush()); // end all output buffers if any
 
-    $cmd = "dotnet Generator/bin/Debug/net5.0/TPRandomizer.dll $settingsString \"$seedHash\"";
+    $cmd = "dotnet Generator/bin/Debug/net5.0/TPRandomizer.dll $settingsString $seedHash";
     $proc = popen($cmd, 'r'); // for Windows, use popen("start /B ". $cmd, 'r'); 
     echo "<h3>TPR 1.0 Seed generator (pre-alpha)</h3><h4>$seedHash</h4><hr><pre>$cmd\n----\n\n";
     $log = "$cmd\n----\n\n";


### PR DESCRIPTION
- Was generating zip files with names like `TPR-v1.0-'[0]-Polite-Diababa'.zip` which includes some single-quotes.
- This ws probably unintentional and caused problems with `generator.php` which was expecting there to be no single-quotes when it checked if the file exists.