### PR TITLE
Add command string to dll interface

### DIFF
--- a/Generator/Program.cs
+++ b/Generator/Program.cs
@@ -10,7 +10,14 @@ namespace TPRandomizer
         [STAThread]
         static void Main(string[] args)
         {
-            Randomizer.Start(args[0], args[1]);
+            string command = args[0];
+
+            switch (command)
+            {
+                case "generate_legacy":
+                    Randomizer.Start(args[1], args[2]);
+                    break;
+            }
         }
     }
 }

--- a/generator.php
+++ b/generator.php
@@ -52,7 +52,7 @@ try
 
     while (@ ob_end_flush()); // end all output buffers if any
 
-    $cmd = "dotnet Generator/bin/Debug/net5.0/TPRandomizer.dll $settingsString $seedHash";
+    $cmd = "dotnet Generator/bin/Debug/net5.0/TPRandomizer.dll generate_legacy $settingsString $seedHash";
     $proc = popen($cmd, 'r'); // for Windows, use popen("start /B ". $cmd, 'r'); 
     echo "<h3>TPR 1.0 Seed generator (pre-alpha)</h3><h4>$seedHash</h4><hr><pre>$cmd\n----\n\n";
     $log = "$cmd\n----\n\n";


### PR DESCRIPTION
- Add command string to dll interface.
- Use "generate_legacy" for current behavior.
- This is in preparation for splitting generation into 2 steps similar to OoTR.